### PR TITLE
Add ExplorerConfig for configurable table names and update validator/UI to use it

### DIFF
--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/ExplorerConfig.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/ExplorerConfig.java
@@ -1,0 +1,98 @@
+package it.geoframe.blogpost.subbasins.explorer.services;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+/**
+ * Application configuration loaded from properties file.
+ *
+ * Lookup order:
+ * 1) explicit path via -Dgeoframe.explorer.config=/path/to/explorer.properties
+ * 2) ~/.geoframe-subbasins-explorer/explorer.properties
+ * 3) classpath resource explorer.properties
+ */
+public final class ExplorerConfig {
+
+	private static final String CONFIG_FILE = "explorer.properties";
+	private static final String EXTERNAL_CONFIG_PROPERTY = "geoframe.explorer.config";
+	private static final Path USER_CONFIG_PATH = Paths.get(System.getProperty("user.home"),
+			".geoframe-subbasins-explorer", CONFIG_FILE);
+	private static final Properties PROPS = loadProperties();
+
+	private ExplorerConfig() {
+	}
+
+	public static String sqliteMeasurementTable() {
+		return get("tables.sqlite.measurement", "measurement");
+	}
+
+	public static String geopackageBasinTable() {
+		return get("tables.geopackage.basin", "basin");
+	}
+
+	public static String geopackageNetworkTable() {
+		return get("tables.geopackage.network", "network");
+	}
+
+	public static String geopackageTopologyPrefix() {
+		return get("tables.geopackage.topology.prefix", "topology");
+	}
+
+	public static String geopackageSimulationPrefix() {
+		return get("tables.geopackage.simulation.prefix", "sim");
+	}
+
+	private static String get(String key, String defaultValue) {
+		String v = PROPS.getProperty(key);
+		return (v == null || v.isBlank()) ? defaultValue : v.trim();
+	}
+
+	private static Properties loadProperties() {
+		Properties p = new Properties();
+		Path externalConfigPath = externalConfigPath();
+		if (loadFromPath(p, externalConfigPath)) {
+			return p;
+		}
+
+		if (loadFromPath(p, USER_CONFIG_PATH)) {
+			return p;
+		}
+
+		loadFromClasspath(p);
+		return p;
+	}
+
+	private static Path externalConfigPath() {
+		String configuredPath = System.getProperty(EXTERNAL_CONFIG_PROPERTY);
+		if (configuredPath == null || configuredPath.isBlank()) {
+			return null;
+		}
+		return Paths.get(configuredPath.trim());
+	}
+
+	private static boolean loadFromPath(Properties p, Path path) {
+		if (path == null || !Files.exists(path) || !Files.isRegularFile(path) || !Files.isReadable(path)) {
+			return false;
+		}
+		try (InputStream in = Files.newInputStream(path)) {
+			p.load(in);
+			return true;
+		} catch (IOException ignored) {
+			return false;
+		}
+	}
+
+	private static void loadFromClasspath(Properties p) {
+		try (InputStream in = ExplorerConfig.class.getClassLoader().getResourceAsStream(CONFIG_FILE)) {
+			if (in != null) {
+				p.load(in);
+			}
+		} catch (IOException ignored) {
+			// Keep defaults if configuration file is unavailable.
+		}
+	}
+}

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/ProjectValidator.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/ProjectValidator.java
@@ -74,16 +74,17 @@ public final class ProjectValidator {
 
 	private static void validateSqlite(Path sqlitePath, List<String> info, List<String> errors, List<String> warnings) {
 		info.add("— Checking SQLite input…");
+		String measurementTable = ExplorerConfig.sqliteMeasurementTable();
 		try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + sqlitePath)) {
 			info.add("✅ SQLite opened successfully.");
 
-			if (!tableExists(c, "measurement")) {
-				errors.add("SQLite: missing table 'measurement'.");
+			if (!tableExists(c, measurementTable)) {
+				errors.add("SQLite: missing table '" + measurementTable + "'.");
 				return;
 			}
-			info.add("✅ SQLite table found: measurement");
+			info.add("✅ SQLite table found: " + measurementTable);
 
-			Set<String> cols = tableColumns(c, "measurement");
+			Set<String> cols = tableColumns(c, measurementTable);
 			requireColumns("SQLite.measurements", cols, Set.of("ts", "basin_id", "value"), info, errors);
 
 			// optional sanity warnings
@@ -97,28 +98,31 @@ public final class ProjectValidator {
 	private static void validateGeoPackageSqliteSide(Path geopkgPath, List<String> info, List<String> errors,
 			List<String> warnings) {
 		info.add("— Checking GeoPackage content (SQLite side)…");
+		String basinTable = ExplorerConfig.geopackageBasinTable();
+		String networkTable = ExplorerConfig.geopackageNetworkTable();
+		String topologyPrefix = ExplorerConfig.geopackageTopologyPrefix();
+		String simulationPrefix = ExplorerConfig.geopackageSimulationPrefix();
 		try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + geopkgPath)) {
 			info.add("✅ GeoPackage opened as SQLite successfully.");
 
 			// Required layers/tables (as per your spec)
-			requireTable(c, "basin", "GeoPackage", info, errors);
-			requireTable(c, "network", "GeoPackage", info, errors);
+			requireTable(c, basinTable, "GeoPackage", info, errors);
+			requireTable(c, networkTable, "GeoPackage", info, errors);
 
-			// "topologi" vs "topology": you mentioned "topologi" earlier; handle both
-			boolean hasTopology = tableExists(c, "topology");
-			if (hasTopology || anyTableStartsWith(c, "topology")) {
-				info.add("✅ GeoPackage table found: " + (hasTopology ? "topology" : "topologi"));
+			boolean hasTopology = tableExists(c, topologyPrefix);
+			if (hasTopology || anyTableStartsWith(c, topologyPrefix)) {
+				info.add("✅ GeoPackage table found: " + topologyPrefix);
 			} else {
-				errors.add("GeoPackage: missing table 'topology' (or 'topologi').");
+				errors.add("GeoPackage: missing table with prefix '" + topologyPrefix + "'.");
 			}
 
 			// at least one table starting with "simulation"
-			boolean hasSimulation = anyTableStartsWith(c, "sim");
+			boolean hasSimulation = anyTableStartsWith(c, simulationPrefix);
 			if (hasSimulation) {
-				List<String> sims = listTablesStartingWith(c, "sim", 10);
+				List<String> sims = listTablesStartingWith(c, simulationPrefix, 10);
 				info.add("✅ GeoPackage simulation tables detected: " + sims + (sims.size() == 10 ? " …" : ""));
 			} else {
-				errors.add("GeoPackage: missing at least one table starting with 'simulation*'.");
+				errors.add("GeoPackage: missing at least one table starting with '" + simulationPrefix + "*'.");
 			}
 
 			// Optional: basic gpkg sanity

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/ui/SubbasinExplorerPanel.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/ui/SubbasinExplorerPanel.java
@@ -1,5 +1,6 @@
 package it.geoframe.blogpost.subbasins.explorer.ui;
 
+import it.geoframe.blogpost.subbasins.explorer.services.ExplorerConfig;
 import it.geoframe.blogpost.subbasins.explorer.services.ProjectConfig;
 import it.geoframe.blogpost.subbasins.explorer.services.ProjectConfigStore;
 import it.geoframe.blogpost.subbasins.explorer.services.ProjectMode;
@@ -250,9 +251,11 @@ public final class SubbasinExplorerPanel extends JPanel {
 		}
 
 		String[] typeNames = dataStore.getTypeNames();
-		String target = Arrays.stream(typeNames).filter(name -> name.equalsIgnoreCase("basin")).findFirst()
+		String basinTable = ExplorerConfig.geopackageBasinTable();
+		String target = Arrays.stream(typeNames).filter(name -> name.equalsIgnoreCase(basinTable)).findFirst()
 				.orElseGet(() -> Arrays.stream(typeNames)
-						.filter(name -> name.toLowerCase(Locale.ROOT).contains("basin")).findFirst().orElse(null));
+						.filter(name -> name.toLowerCase(Locale.ROOT).contains(basinTable.toLowerCase(Locale.ROOT)))
+						.findFirst().orElse(null));
 
 		if (target == null) {
 			return Optional.empty();
@@ -266,9 +269,11 @@ public final class SubbasinExplorerPanel extends JPanel {
 			return null;
 		}
 		String[] typeNames = dataStore.getTypeNames();
-		String target = Arrays.stream(typeNames).filter(name -> name.equalsIgnoreCase("network")).findFirst()
+		String networkTable = ExplorerConfig.geopackageNetworkTable();
+		String target = Arrays.stream(typeNames).filter(name -> name.equalsIgnoreCase(networkTable)).findFirst()
 				.orElseGet(() -> Arrays.stream(typeNames)
-						.filter(name -> name.toLowerCase(Locale.ROOT).contains("network")).findFirst().orElse(null));
+						.filter(name -> name.toLowerCase(Locale.ROOT).contains(networkTable.toLowerCase(Locale.ROOT)))
+						.findFirst().orElse(null));
 		if (target == null) {
 			return null;
 		}

--- a/src/main/resources/explorer.properties
+++ b/src/main/resources/explorer.properties
@@ -1,0 +1,10 @@
+# Database table/layer names used by validation and map loading.
+tables.sqlite.measurement=measurement
+
+# GeoPackage layers
+tables.geopackage.basin=basin
+tables.geopackage.network=network
+
+# Prefixes
+tables.geopackage.topology.prefix=topology
+tables.geopackage.simulation.prefix=sim


### PR DESCRIPTION
### Motivation
- Make database table and layer names configurable so the tool can work with projects that use nonstandard naming.
- Centralize configuration loading with a predictable lookup order (system property, user home, classpath) to allow overrides.
- Replace hard-coded table names in validation and UI code to avoid duplication and improve maintainability.

### Description
- Add `it.geoframe.blogpost.subbasins.explorer.services.ExplorerConfig` which loads `explorer.properties` from `-Dgeoframe.explorer.config`, `~/.geoframe-subbasins-explorer/`, or the classpath and exposes accessors like `sqliteMeasurementTable()`, `geopackageBasinTable()`, `geopackageNetworkTable()`, `geopackageTopologyPrefix()`, and `geopackageSimulationPrefix()`.
- Update `ProjectValidator` to use `ExplorerConfig` values for the SQLite measurement table and GeoPackage basin/network/topology/simulation names and prefixes during validation messages and checks.
- Update `SubbasinExplorerPanel` to consult `ExplorerConfig` when selecting GeoPackage feature types for `basin` and `network` instead of relying on hard-coded names and substring checks.
- Add a default `src/main/resources/explorer.properties` with keys for the SQLite and GeoPackage tables and prefixes to provide sensible defaults.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ea71becbc8325a85b2c241e295779)