### PR TITLE
Refactor timeseries loading to reduce hardcoded table/column assumptions

### DIFF
--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/ExplorerConfig.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/ExplorerConfig.java
@@ -46,6 +46,19 @@ public final class ExplorerConfig {
 		return get("tables.geopackage.simulation.prefix", "sim");
 	}
 
+	public static String timeseriesTimestampColumn() {
+		return get("tables.timeseries.columns.timestamp", "ts");
+	}
+
+	public static String timeseriesValueColumn() {
+		return get("tables.timeseries.columns.value", "value");
+	}
+
+	public static String[] timeseriesBasinIdCandidates() {
+		String configured = get("tables.timeseries.columns.basin-id.candidates", "basin_id,basinid,id");
+		return configured.split(",");
+	}
+
 	private static String get(String key, String defaultValue) {
 		String v = PROPS.getProperty(key);
 		return (v == null || v.isBlank()) ? defaultValue : v.trim();

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/TimeseriesRepository.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/TimeseriesRepository.java
@@ -1,0 +1,79 @@
+package it.geoframe.blogpost.subbasins.explorer.services;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Repository dedicated to time-series table discovery and extraction.
+ */
+public final class TimeseriesRepository {
+
+	public List<String> listTables(Path dbPath) {
+		if (dbPath == null) {
+			return List.of();
+		}
+		List<String> out = new ArrayList<>();
+		String sql = "SELECT name FROM sqlite_master WHERE type IN ('table','view') ORDER BY name";
+		try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
+				PreparedStatement ps = c.prepareStatement(sql);
+				ResultSet rs = ps.executeQuery()) {
+			while (rs.next()) {
+				out.add(rs.getString(1));
+			}
+		} catch (SQLException ignored) {
+			return List.of();
+		}
+		return out;
+	}
+
+	public Set<String> listColumnNames(Path dbPath, String tableName) {
+		if (dbPath == null || tableName == null || tableName.isBlank()) {
+			return Set.of();
+		}
+		String safeTable = tableName.replace("\"", "\"\"");
+		String sql = "SELECT * FROM \"" + safeTable + "\" LIMIT 1";
+		Set<String> out = new LinkedHashSet<>();
+		try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
+				PreparedStatement ps = c.prepareStatement(sql);
+				ResultSet rs = ps.executeQuery()) {
+			ResultSetMetaData md = rs.getMetaData();
+			for (int i = 1; i <= md.getColumnCount(); i++) {
+				String columnName = md.getColumnName(i);
+				if (columnName != null) {
+					out.add(columnName);
+				}
+			}
+		} catch (SQLException ignored) {
+			return Set.of();
+		}
+		return out;
+	}
+
+	public Optional<String> findFirstColumnIgnoreCase(Set<String> columns, String[] candidates) {
+		if (columns == null || columns.isEmpty() || candidates == null) {
+			return Optional.empty();
+		}
+		for (String candidate : candidates) {
+			if (candidate == null || candidate.isBlank()) {
+				continue;
+			}
+			String trimmed = candidate.trim();
+			for (String column : columns) {
+				if (column.equalsIgnoreCase(trimmed)) {
+					return Optional.of(column);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+}

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/ui/SubbasinExplorerPanel.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/ui/SubbasinExplorerPanel.java
@@ -80,6 +80,7 @@ import it.geoframe.blogpost.subbasins.explorer.services.ProjectConfig;
 import it.geoframe.blogpost.subbasins.explorer.services.ProjectConfigStore;
 import it.geoframe.blogpost.subbasins.explorer.services.ProjectMode;
 import it.geoframe.blogpost.subbasins.explorer.services.ProjectValidator;
+import it.geoframe.blogpost.subbasins.explorer.services.TimeseriesRepository;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;
@@ -106,6 +107,7 @@ public final class SubbasinExplorerPanel extends JPanel {
 	private String selectedFeatureId;
 	private String selectedSubbasinId;
 	private TimeseriesWindow timeseriesWindow;
+	private final TimeseriesRepository timeseriesRepository = new TimeseriesRepository();
 
 	private DataStore dataStore;
 	private SimpleFeatureSource subbasinSource;
@@ -238,30 +240,12 @@ public final class SubbasinExplorerPanel extends JPanel {
 	}
 
 	private List<String> loadAllTableNamesFromInputs() {
-		List<String> out = new ArrayList<>();
 		if (config == null) {
-			return out;
-		}
-		out.addAll(listTableNamesFromDb(config.geopackagePath()));
-		out.addAll(listTableNamesFromDb(config.sqlitePath()));
-		return out;
-	}
-
-	private List<String> listTableNamesFromDb(java.nio.file.Path dbPath) {
-		if (dbPath == null) {
 			return List.of();
 		}
 		List<String> out = new ArrayList<>();
-		String sql = "SELECT name FROM sqlite_master WHERE type IN ('table','view') ORDER BY name";
-		try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
-				PreparedStatement ps = c.prepareStatement(sql);
-				ResultSet rs = ps.executeQuery()) {
-			while (rs.next()) {
-				out.add(rs.getString(1));
-			}
-		} catch (SQLException e) {
-			statusLabel.setText("Errore lettura tabelle da " + dbPath.getFileName() + ": " + e.getMessage());
-		}
+		out.addAll(timeseriesRepository.listTables(config.geopackagePath()));
+		out.addAll(timeseriesRepository.listTables(config.sqlitePath()));
 		return out;
 	}
 
@@ -819,23 +803,39 @@ public final class SubbasinExplorerPanel extends JPanel {
 
 		private int fillSeriesFromAnyInput(String table, String basinId, TimeSeries series) {
 			int count = fillSeriesFromDb(config.geopackagePath(), table, basinId, series);
-			if (count > 0) return count;
+			if (count > 0) {
+				return count;
+			}
 			return fillSeriesFromDb(config.sqlitePath(), table, basinId, series);
 		}
 
 		private int fillSeriesFromDb(java.nio.file.Path dbPath, String table, String basinId, TimeSeries series) {
-			if (dbPath == null) return 0;
+			if (dbPath == null || table == null || basinId == null) {
+				return 0;
+			}
+
+			Set<String> columns = timeseriesRepository.listColumnNames(dbPath, table);
+			Optional<String> basinColumn = timeseriesRepository.findFirstColumnIgnoreCase(columns,
+					ExplorerConfig.timeseriesBasinIdCandidates());
+			Optional<String> tsColumn = timeseriesRepository.findFirstColumnIgnoreCase(columns,
+					new String[] { ExplorerConfig.timeseriesTimestampColumn(), "timestamp", "date", "time" });
+			Optional<String> valueColumn = timeseriesRepository.findFirstColumnIgnoreCase(columns,
+					new String[] { ExplorerConfig.timeseriesValueColumn(), "simulated", "obs", "q" });
+			if (basinColumn.isEmpty() || tsColumn.isEmpty() || valueColumn.isEmpty()) {
+				return 0;
+			}
+
 			String safeTable = table.replace("\"", "\"\"");
-			//@todo basiid!!!! 
-			String sql = "SELECT ts, value FROM \"" + safeTable + "\" WHERE basin_id=? ORDER BY ts";
+			String sql = "SELECT \"" + tsColumn.get() + "\", \"" + valueColumn.get() + "\" FROM \"" + safeTable
+					+ "\" WHERE \"" + basinColumn.get() + "\"=? ORDER BY \"" + tsColumn.get() + "\"";
 			try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
 					PreparedStatement ps = c.prepareStatement(sql)) {
-				ps.setInt(1, Integer.valueOf(basinId));
+				ps.setString(1, basinId);
 				int count = 0;
 				try (ResultSet rs = ps.executeQuery()) {
 					while (rs.next()) {
-						long ts = rs.getLong("ts");
-						double value = rs.getDouble("value");
+						long ts = rs.getLong(1);
+						double value = rs.getDouble(2);
 						if (!rs.wasNull()) {
 							series.addOrUpdate(new Millisecond(new java.util.Date(ts)), value);
 							count++;


### PR DESCRIPTION
### Motivation
- Timeseries loading in the UI relied on hardcoded table/column names (`ts`, `value`, `basin_id`) and embedded SQL helpers inside a large UI class, which made the code fragile when input schemas differ. 
- The change moves DB discovery/introspection out of the UI so the panel can adapt to different schema conventions and be easier to maintain. 
- Make the column names configurable via properties so behavior can be adjusted without changing Java code.

### Description
- Add `TimeseriesRepository` to centralize SQLite/GeoPackage timeseries table discovery and schema introspection (`listTables`, `listColumnNames`, `findFirstColumnIgnoreCase`).
- Extend `ExplorerConfig` with new keys and accessors: `timeseriesTimestampColumn()`, `timeseriesValueColumn()`, and `timeseriesBasinIdCandidates()` to allow configurable column names. 
- Update `SubbasinExplorerPanel` to use `TimeseriesRepository` for listing tables and to dynamically resolve `basin id`, `timestamp` and `value` columns before building the query, replacing previous hardcoded SQL and column access. 
- Adjusted SQL binding to use `ps.setString(1, basinId)` and read result columns by index after dynamic resolution; kept sensible fallbacks for timestamp and value column names.

### Testing
- Attempted to compile the project with `mvn -q -DskipTests compile`, but the build failed due to Maven plugin resolution errors contacting central (HTTP 403) in this environment. 
- Attempted offline compile with `mvn -q -DskipTests -o compile`, which failed because the required Maven plugin artifacts are not present in the local cache, so a full compile could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a01828881083259c2574160ba3a356)