### PR TITLE
Add line selection/removal controls to timeseries chart

### DIFF
--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/plot/TimeseriesWindow.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/plot/TimeseriesWindow.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -47,6 +48,7 @@ public final class TimeseriesWindow {
 	private final JComboBox<String> tableCombo;
 	private final JComboBox<String> basinCombo;
 	private final JComboBox<String> streamGaugeCombo;
+	private final JComboBox<String> seriesCombo;
 	private final JTextArea statusArea;
 	private final TimeSeriesCollection dataset;
 	private String activeType;
@@ -81,6 +83,7 @@ public final class TimeseriesWindow {
 		tableCombo = new JComboBox<>();
 		basinCombo = new JComboBox<>();
 		streamGaugeCombo = new JComboBox<>();
+		seriesCombo = new JComboBox<>();
 		controlsPanel.add(new JLabel("Tabella da aggiungere:"), gbc);
 		gbc.gridy++;
 		controlsPanel.add(tableCombo, gbc);
@@ -106,6 +109,14 @@ public final class TimeseriesWindow {
 		JButton clearExtraLinesButton = new JButton("Tieni solo portata base");
 		clearExtraLinesButton.addActionListener(e -> keepOnlyBaseSeries());
 		controlsPanel.add(clearExtraLinesButton, gbc);
+		gbc.gridy++;
+		controlsPanel.add(new JLabel("Linee nel grafico:"), gbc);
+		gbc.gridy++;
+		controlsPanel.add(seriesCombo, gbc);
+		gbc.gridy++;
+		JButton removeSelectedLineButton = new JButton("Elimina linea selezionata");
+		removeSelectedLineButton.addActionListener(e -> removeSelectedSeries());
+		controlsPanel.add(removeSelectedLineButton, gbc);
 		statusArea = new JTextArea();
 		statusArea.setEditable(false);
 		statusArea.setLineWrap(true);
@@ -122,6 +133,7 @@ public final class TimeseriesWindow {
 		this.activeType = type == null ? "discharge" : type;
 		dataset.removeAllSeries();
 		baseSeriesKey = null;
+		reloadSeriesCombo();
 		reloadCombos();
 		if (subbasinId != null) {
 			basinCombo.setSelectedItem(subbasinId);
@@ -201,6 +213,7 @@ public final class TimeseriesWindow {
 		}
 		dataset.addSeries(series);
 		applySeriesStyles();
+		reloadSeriesCombo();
 		statusArea.setText("Aggiunta serie: " + table + "\nBasin ID: " + basinId + "\nPunti: " + count);
 	}
 
@@ -222,13 +235,40 @@ public final class TimeseriesWindow {
 			statusArea.setText("Non ci sono linee aggiuntive da rimuovere.");
 			return;
 		}
-		for (int i = dataset.getSeriesCount() - 1; i >= 0; i--) {
-			String key = dataset.getSeries(i).getKey().toString();
-			if (!key.equals(baseSeriesKey)) {
-				dataset.removeSeries(i);
-			}
+		for (int i = dataset.getSeriesCount() - 1; i >= 1; i--) {
+			dataset.removeSeries(i);
 		}
 		applySeriesStyles();
+		reloadSeriesCombo();
 		statusArea.setText("Rimosse le linee aggiuntive. Tenuta solo la portata base.");
+	}
+
+	private void reloadSeriesCombo() {
+		DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
+		for (int i = 0; i < dataset.getSeriesCount(); i++) {
+			model.addElement(dataset.getSeries(i).getKey().toString());
+		}
+		seriesCombo.setModel(model);
+	}
+
+	private void removeSelectedSeries() {
+		if (dataset.getSeriesCount() == 0) {
+			statusArea.setText("Non ci sono linee da eliminare.");
+			return;
+		}
+		int selectedIndex = seriesCombo.getSelectedIndex();
+		if (selectedIndex < 0 || selectedIndex >= dataset.getSeriesCount()) {
+			statusArea.setText("Seleziona una linea da eliminare.");
+			return;
+		}
+		if (selectedIndex == 0) {
+			statusArea.setText("La portata base non può essere eliminata.");
+			return;
+		}
+		String removedKey = dataset.getSeries(selectedIndex).getKey().toString();
+		dataset.removeSeries(selectedIndex);
+		applySeriesStyles();
+		reloadSeriesCombo();
+		statusArea.setText("Linea eliminata: " + removedKey);
 	}
 }


### PR DESCRIPTION
### Motivation
- The timeseries chart needed a way to list plotted lines and let the user remove a specific one, and the existing "Tieni solo portata base" action did not always remove all extra lines reliably.

### Description
- Added a `seriesCombo` selector and the `DefaultComboBoxModel` import to display the list of series currently plotted in the chart.
- Added a new button `Elimina linea selezionata` and the `removeSelectedSeries()` method to remove the user-selected series while protecting the base series (index 0).
- Made `keepOnlyBaseSeries()` reliably keep only the first/base series by removing all series from the end down to index `1`, and synchronized the UI by adding `reloadSeriesCombo()` calls when series are added, removed, or the chart is reset.
- `reloadSeriesCombo()` builds and sets the model from the `dataset` so the selector is kept in sync with the plotted series.

### Testing
- Attempted to compile with Maven using `mvn -q -DskipTests compile`, but the build failed in this environment due to inability to resolve `maven-resources-plugin:3.3.1` from Maven Central (HTTP 403), so no successful automated build/test run completed.
- No unit tests were executed in this environment because compilation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a020d55a808325988f5cc156c44ddc)