### PR TITLE
Add dedicated state/fluxes chart behavior and pan/zoom controls

### DIFF
--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/io/TimeseriesLoader.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/io/TimeseriesLoader.java
@@ -7,8 +7,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -19,6 +21,8 @@ import it.geoframe.blogpost.subbasins.explorer.services.ExplorerConfig;
 import it.geoframe.blogpost.subbasins.explorer.services.ProjectConfig;
 
 public final class TimeseriesLoader {
+	public record TimeValueRow(long timestamp, Map<String, Double> values) {
+	}
 
 	private final TimeseriesRepository repository;
 
@@ -52,6 +56,15 @@ public final class TimeseriesLoader {
 		out.addAll(repository.listColumnNames(config.geopackagePath(), table));
 		out.addAll(repository.listColumnNames(config.sqlitePath(), table));
 		return out;
+	}
+
+	public List<TimeValueRow> loadRowsFromAnyInput(ProjectConfig config, String table, String basinId,
+			String... valueColumns) {
+		List<TimeValueRow> rows = loadRowsFromDb(config.geopackagePath(), table, basinId, valueColumns);
+		if (!rows.isEmpty()) {
+			return rows;
+		}
+		return loadRowsFromDb(config.sqlitePath(), table, basinId, valueColumns);
 	}
 
 	private int fillSeriesFromDb(Path dbPath, String table, String basinId, TimeSeries series) {
@@ -91,5 +104,53 @@ public final class TimeseriesLoader {
 		} catch (SQLException ex) {
 			return 0;
 		}
+	}
+
+	private List<TimeValueRow> loadRowsFromDb(Path dbPath, String table, String basinId, String... valueColumns) {
+		if (dbPath == null || table == null || basinId == null || valueColumns == null || valueColumns.length == 0) {
+			return List.of();
+		}
+		Set<String> columns = repository.listColumnNames(dbPath, table);
+		Optional<String> basinColumn = repository.findFirstColumnIgnoreCase(columns,
+				ExplorerConfig.timeseriesBasinIdCandidates());
+		Optional<String> tsColumn = repository.findFirstColumnIgnoreCase(columns,
+				new String[] { ExplorerConfig.timeseriesTimestampColumn(), "timestamp", "date", "time" });
+		if (basinColumn.isEmpty() || tsColumn.isEmpty()) {
+			return List.of();
+		}
+		Map<String, String> resolvedColumns = new LinkedHashMap<>();
+		for (String col : valueColumns) {
+			Optional<String> resolved = repository.findFirstColumnIgnoreCase(columns, new String[] { col });
+			if (resolved.isEmpty()) {
+				return List.of();
+			}
+			resolvedColumns.put(col, resolved.get());
+		}
+
+		StringBuilder select = new StringBuilder("SELECT \"").append(tsColumn.get()).append("\"");
+		for (String actual : resolvedColumns.values()) {
+			select.append(", \"").append(actual).append("\"");
+		}
+		String safeTable = table.replace("\"", "\"\"");
+		String sql = select + " FROM \"" + safeTable + "\" WHERE \"" + basinColumn.get() + "\"=? ORDER BY \""
+				+ tsColumn.get() + "\"";
+		List<TimeValueRow> out = new ArrayList<>();
+		try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
+				PreparedStatement ps = c.prepareStatement(sql)) {
+			ps.setString(1, basinId);
+			try (ResultSet rs = ps.executeQuery()) {
+				while (rs.next()) {
+					Map<String, Double> vals = new LinkedHashMap<>();
+					for (int i = 0; i < valueColumns.length; i++) {
+						double v = rs.getDouble(i + 2);
+						vals.put(valueColumns[i], rs.wasNull() ? Double.NaN : v);
+					}
+					out.add(new TimeValueRow(rs.getLong(1), vals));
+				}
+			}
+		} catch (SQLException ex) {
+			return List.of();
+		}
+		return out;
 	}
 }

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/plot/ChartSetupDialog.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/plot/ChartSetupDialog.java
@@ -6,6 +6,9 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.function.Consumer;
 
 import javax.swing.JButton;
@@ -23,6 +26,7 @@ public final class ChartSetupDialog {
 	private final JDialog dialog = new JDialog();
 	private final JComboBox<String> simulationCombo = new JComboBox<>();
 	private final JComboBox<String> typeCombo = new JComboBox<>(new String[] { "discharge", "state", "fluxes" });
+	private final List<String> allSimulationTables = new ArrayList<>();
 
 	public ChartSetupDialog(Component parent, ProjectMode mode, String[] simulationTables, Consumer<ChartRequest> onConfirm) {
 		dialog.setModal(false);
@@ -40,14 +44,16 @@ public final class ChartSetupDialog {
 			panel.add(new JLabel("Simulazione da plottare:"), gbc);
 			gbc.gridy++;
 			for (String t : simulationTables) {
-				simulationCombo.addItem(t);
+				allSimulationTables.add(t);
 			}
+			reloadSimulationCombo();
 			panel.add(simulationCombo, gbc);
 			gbc.gridy++;
 		}
 		panel.add(new JLabel("Tipo grafico:"), gbc);
 		gbc.gridy++;
 		panel.add(typeCombo, gbc);
+		typeCombo.addActionListener(e -> reloadSimulationCombo());
 		gbc.gridy++;
 		JButton nextButton = new JButton("Avanti");
 		nextButton.addActionListener(e -> {
@@ -58,6 +64,25 @@ public final class ChartSetupDialog {
 		dialog.add(panel, BorderLayout.CENTER);
 		dialog.setSize(new Dimension(420, 260));
 		dialog.setLocationRelativeTo(parent);
+	}
+
+	private void reloadSimulationCombo() {
+		simulationCombo.removeAllItems();
+		String type = ((String) typeCombo.getSelectedItem());
+		for (String table : allSimulationTables) {
+			if (table == null) {
+				continue;
+			}
+			String normalized = table.toLowerCase(Locale.ROOT);
+			boolean isDischarge = normalized.contains("discharge");
+			if ("discharge".equalsIgnoreCase(type) && !isDischarge) {
+				continue;
+			}
+			if (("state".equalsIgnoreCase(type) || "fluxes".equalsIgnoreCase(type)) && isDischarge) {
+				continue;
+			}
+			simulationCombo.addItem(table);
+		}
 	}
 
 	public void showDialog() {

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/plot/TimeseriesWindow.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/plot/TimeseriesWindow.java
@@ -18,9 +18,9 @@ import java.util.TimeZone;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
+import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
-import javax.swing.DefaultListModel;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -37,10 +37,13 @@ import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.StackedXYAreaRenderer2;
 import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
+import org.jfree.data.time.Millisecond;
 import org.jfree.data.time.TimeSeries;
 import org.jfree.data.time.TimeSeriesCollection;
 import org.jfree.data.time.TimeSeriesDataItem;
+import org.jfree.data.time.TimeTableXYDataset;
 
 import it.geoframe.blogpost.subbasins.explorer.io.TimeseriesLoader;
 import it.geoframe.blogpost.subbasins.explorer.services.ProjectConfig;
@@ -65,6 +68,11 @@ public final class TimeseriesWindow {
 	private String activeType;
 	private String baseSeriesKey;
 	private final XYLineAndShapeRenderer renderer;
+	private final StackedXYAreaRenderer2 stackedRenderer;
+	private final XYPlot plot;
+	private final ChartPanel chartPanel;
+	private final JButton addGaugeButton;
+	private final JButton metricsButton;
 
 	public TimeseriesWindow(Component parent, ProjectConfig config, TimeseriesLoader loader,
 			Supplier<List<String>> tableSupplier, Supplier<List<String>> basinSupplier,
@@ -82,9 +90,13 @@ public final class TimeseriesWindow {
 		dataset = new TimeSeriesCollection();
 		JFreeChart chart = ChartFactory.createTimeSeriesChart("Timeseries", "Tempo", "Valore", dataset, true, true,
 				false);
-		XYPlot plot = chart.getXYPlot();
+		plot = chart.getXYPlot();
 		renderer = new XYLineAndShapeRenderer(true, false);
+		stackedRenderer = new StackedXYAreaRenderer2();
 		plot.setRenderer(renderer);
+		plot.setDomainPannable(true);
+		plot.setRangePannable(true);
+
 		JPanel controlsPanel = new JPanel(new GridBagLayout());
 		GridBagConstraints gbc = new GridBagConstraints();
 		gbc.insets = new Insets(4, 4, 4, 4);
@@ -115,13 +127,34 @@ public final class TimeseriesWindow {
 		gbc.gridy++;
 		controlsPanel.add(streamGaugeCombo, gbc);
 		gbc.gridy++;
-		JButton addGaugeButton = new JButton("Carica stream gauge");
+		addGaugeButton = new JButton("Carica stream gauge");
 		addGaugeButton.addActionListener(e -> addSelectedSeriesFromGaugeCombo());
 		controlsPanel.add(addGaugeButton, gbc);
 		gbc.gridy++;
-		JButton metricsButton = new JButton("Calcola metriche (KGE, NSE, NSElog)");
+		metricsButton = new JButton("Calcola metriche (KGE, NSE, NSElog)");
 		metricsButton.addActionListener(e -> showMetricsPopup());
 		controlsPanel.add(metricsButton, gbc);
+		gbc.gridy++;
+		JButton panButton = new JButton("Pan ON/OFF");
+		panButton.addActionListener(e -> {
+			boolean next = !plot.isDomainPannable();
+			plot.setDomainPannable(next);
+			plot.setRangePannable(next);
+			appendLog("Pan " + (next ? "attivato" : "disattivato") + ".");
+		});
+		controlsPanel.add(panButton, gbc);
+		gbc.gridy++;
+		JButton zoomRectButton = new JButton("Zoom rettangolo ON/OFF");
+		zoomRectButton.addActionListener(e -> {
+			boolean next = !chartPanel.getFillZoomRectangle();
+			chartPanel.setFillZoomRectangle(next);
+			appendLog("Zoom rettangolo " + (next ? "attivato" : "disattivato") + ".");
+		});
+		controlsPanel.add(zoomRectButton, gbc);
+		gbc.gridy++;
+		JButton resetZoomButton = new JButton("Reset zoom");
+		resetZoomButton.addActionListener(e -> chartPanel.restoreAutoBounds());
+		controlsPanel.add(resetZoomButton, gbc);
 		gbc.gridy++;
 		controlsPanel.add(new JLabel("Linee nel grafico:"), gbc);
 		gbc.gridy++;
@@ -142,7 +175,10 @@ public final class TimeseriesWindow {
 		JScrollPane consoleScroll = new JScrollPane(statusArea);
 		consoleScroll.setPreferredSize(new Dimension(1000, 220));
 
-		JSplitPane rightSplit = new JSplitPane(JSplitPane.VERTICAL_SPLIT, new ChartPanel(chart), consoleScroll);
+		chartPanel = new ChartPanel(chart);
+		chartPanel.setMouseWheelEnabled(true);
+		chartPanel.setMouseZoomable(true, false);
+		JSplitPane rightSplit = new JSplitPane(JSplitPane.VERTICAL_SPLIT, chartPanel, consoleScroll);
 		rightSplit.setResizeWeight(0.68);
 		rightSplit.setContinuousLayout(true);
 		JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, controlsPanel, rightSplit);
@@ -158,15 +194,20 @@ public final class TimeseriesWindow {
 		baseSeriesKey = null;
 		reloadSeriesList();
 		reloadCombos();
+		boolean dischargeView = "discharge".equalsIgnoreCase(activeType);
+		addGaugeButton.setEnabled(dischargeView);
+		metricsButton.setEnabled(dischargeView);
 		if (subbasinId != null) {
 			basinCombo.setSelectedItem(subbasinId);
 		}
 		if (firstTable != null) {
 			simulationTableCombo.setSelectedItem(firstTable);
 		}
+		plot.setDataset(dataset);
+		plot.setRenderer(renderer);
 		dialog.setTitle("Vista " + activeType);
 		dialog.setVisible(true);
-		appendLog("Aperta vista portate per sottobacino " + String.valueOf(subbasinId) + ".");
+		appendLog("Aperta vista " + activeType + " per sottobacino " + String.valueOf(subbasinId) + ".");
 		addSelectedSeriesFromSimulationCombo();
 	}
 
@@ -193,7 +234,16 @@ public final class TimeseriesWindow {
 		}
 		List<String> filtered = new ArrayList<>();
 		for (String table : sourceTables) {
-			if (table != null && containsAny(table, "discharge", "sim", activeType)) {
+			if (table == null) {
+				continue;
+			}
+			String lower = table.toLowerCase(Locale.ROOT);
+			boolean isDischarge = lower.contains("discharge");
+			if ("discharge".equalsIgnoreCase(activeType) && isDischarge) {
+				filtered.add(table);
+			}
+			if (("state".equalsIgnoreCase(activeType) || "fluxes".equalsIgnoreCase(activeType))
+					&& lower.contains("sim") && !isDischarge) {
 				filtered.add(table);
 			}
 		}
@@ -234,22 +284,126 @@ public final class TimeseriesWindow {
 		return false;
 	}
 
-	private boolean containsAny(String table, String... tokens) {
-		if (table == null || tokens == null) {
-			return false;
-		}
-		String normalized = table.toLowerCase(Locale.ROOT);
-		for (String token : tokens) {
-			if (token != null && !token.isBlank() && normalized.contains(token.toLowerCase(Locale.ROOT))) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	private void addSelectedSeriesFromSimulationCombo() {
 		String table = (String) simulationTableCombo.getSelectedItem();
+		if ("fluxes".equalsIgnoreCase(activeType)) {
+			addFluxesSeries(table);
+			return;
+		}
+		if ("state".equalsIgnoreCase(activeType)) {
+			addStateSeries(table);
+			return;
+		}
 		addSeries(table, false);
+	}
+
+	private void addFluxesSeries(String table) {
+		String basinId = (String) basinCombo.getSelectedItem();
+		if (table == null || basinId == null) {
+			appendLog("Seleziona tabella e sottobacino.");
+			return;
+		}
+		dataset.removeAllSeries();
+		baseSeriesKey = null;
+		List<TimeseriesLoader.TimeValueRow> rows = loader.loadRowsFromAnyInput(config, table, basinId, "melting_discharge",
+				"canopy_throughfall", "canopy_aet", "rootzone_aet", "root_zone_recharge", "ground_discharge",
+				"runoff_discharge", "rootzone_quick");
+		if (rows.isEmpty()) {
+			appendLog("Nessun dato fluxes trovato in " + table + " per basin " + basinId + ".");
+			return;
+		}
+		addLineSeries(rows, "melting_discharge", "melting_discharg", new Color(117, 196, 255));
+		addLineSeries(rows, "canopy_throughfall", "canopy_throughfall", new Color(34, 197, 94));
+		addSummedLineSeries(rows, "canopy_aet + rootzone_aet", new String[] { "canopy_aet", "rootzone_aet" },
+				new Color(249, 115, 22));
+		addLineSeries(rows, "root_zone_recharge", "root_zone_recharge", new Color(120, 72, 32));
+		addLineSeries(rows, "ground_discharge", "ground_discharge", Color.GRAY);
+		addLineSeries(rows, "runoff_discharge", "runoff_discharge", Color.BLUE);
+		addLineSeries(rows, "rootzone_quick", "rootzone_quick", new Color(79, 70, 229));
+		reloadSeriesList();
+		appendLog("Caricate serie fluxes da " + table + " | basin " + basinId + " | punti: " + rows.size());
+	}
+
+	private void addStateSeries(String table) {
+		String basinId = (String) basinCombo.getSelectedItem();
+		if (table == null || basinId == null) {
+			appendLog("Seleziona tabella e sottobacino.");
+			return;
+		}
+		List<TimeseriesLoader.TimeValueRow> rows = loader.loadRowsFromAnyInput(config, table, basinId, "swe", "rootzone_aet",
+				"canopy_aet", "canopy_final", "canopy_initial", "rootzone_final", "rootzone_initial",
+				"runoff_final", "runoff_initial", "ground_final", "ground_initial");
+		if (rows.isEmpty()) {
+			appendLog("Nessun dato state trovato in " + table + " per basin " + basinId + ".");
+			return;
+		}
+		TimeTableXYDataset stateDataset = new TimeTableXYDataset();
+		for (TimeseriesLoader.TimeValueRow row : rows) {
+			Date date = new Date(row.timestamp());
+			stateDataset.add(new Millisecond(date), value(row, "swe"), "swe");
+			stateDataset.add(new Millisecond(date), value(row, "rootzone_aet") + value(row, "canopy_aet"),
+					"rootzone_aet + canopy_aet");
+			stateDataset.add(new Millisecond(date), value(row, "canopy_final") - value(row, "canopy_initial"),
+					"canopy_final - canopy_initial");
+			stateDataset.add(new Millisecond(date), value(row, "rootzone_final") - value(row, "rootzone_initial"),
+					"rootzone_final - rootzone_initial");
+			stateDataset.add(new Millisecond(date), value(row, "runoff_final") - value(row, "runoff_initial"),
+					"runoff_final - runoff_initial");
+			stateDataset.add(new Millisecond(date), value(row, "ground_final") - value(row, "ground_initial"),
+					"ground_final - ground_initial");
+		}
+		plot.setDataset(stateDataset);
+		plot.setRenderer(stackedRenderer);
+		stackedRenderer.setSeriesPaint(0, Color.GRAY);
+		stackedRenderer.setSeriesPaint(1, new Color(249, 115, 22));
+		stackedRenderer.setSeriesPaint(2, new Color(34, 197, 94));
+		stackedRenderer.setSeriesPaint(3, new Color(120, 72, 32));
+		stackedRenderer.setSeriesPaint(4, Color.BLUE);
+		stackedRenderer.setSeriesPaint(5, new Color(125, 125, 125));
+		dataset.removeAllSeries();
+		reloadSeriesList();
+		appendLog("Caricate serie state impilate da " + table + " | basin " + basinId + " | punti: " + rows.size());
+	}
+
+	private void addLineSeries(List<TimeseriesLoader.TimeValueRow> rows, String key, String label, Color color) {
+		TimeSeries series = new TimeSeries(label);
+		for (TimeseriesLoader.TimeValueRow row : rows) {
+			double v = value(row, key);
+			if (Double.isFinite(v)) {
+				series.addOrUpdate(new Millisecond(new Date(row.timestamp())), v);
+			}
+		}
+		dataset.addSeries(series);
+		renderer.setSeriesPaint(dataset.getSeriesCount() - 1, color);
+	}
+
+	private void addSummedLineSeries(List<TimeseriesLoader.TimeValueRow> rows, String label, String[] keys, Color color) {
+		TimeSeries series = new TimeSeries(label);
+		for (TimeseriesLoader.TimeValueRow row : rows) {
+			double sum = 0d;
+			boolean valid = true;
+			for (String key : keys) {
+				double v = value(row, key);
+				if (!Double.isFinite(v)) {
+					valid = false;
+					break;
+				}
+				sum += v;
+			}
+			if (valid) {
+				series.addOrUpdate(new Millisecond(new Date(row.timestamp())), sum);
+			}
+		}
+		dataset.addSeries(series);
+		renderer.setSeriesPaint(dataset.getSeriesCount() - 1, color);
+	}
+
+	private double value(TimeseriesLoader.TimeValueRow row, String key) {
+		if (row == null || row.values() == null) {
+			return Double.NaN;
+		}
+		Double v = row.values().get(key);
+		return v == null ? Double.NaN : v.doubleValue();
 	}
 
 	private void addSelectedSeriesFromGaugeCombo() {

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/ProjectValidator.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/services/ProjectValidator.java
@@ -222,6 +222,24 @@ public final class ProjectValidator {
 		}
 	}
 
+	public static List<String> listSimulationTables(Path sqliteDbPath, String simulationPrefix, int limit)
+			throws SQLException {
+		try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + sqliteDbPath)) {
+			List<String> out = new ArrayList<>();
+			try (PreparedStatement ps = c.prepareStatement(
+					"SELECT name FROM sqlite_master WHERE type IN ('table','view') AND lower(name) LIKE lower(?) ORDER BY name LIMIT ?")) {
+				ps.setString(1, simulationPrefix + "%");
+				ps.setInt(2, limit);
+				try (ResultSet rs = ps.executeQuery()) {
+					while (rs.next()) {
+						out.add(rs.getString(1));
+					}
+				}
+			}
+			return out;
+		}
+	}
+
 	private static List<String> listSimulationDischargeTables(Connection c, String simulationPrefix, int limit)
 			throws SQLException {
 		List<String> out = new ArrayList<>();

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/ui/SubbasinExplorerPanel.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/ui/SubbasinExplorerPanel.java
@@ -228,7 +228,7 @@ public final class SubbasinExplorerPanel extends JPanel {
 			return new String[0];
 		}
 		try {
-			List<String> simulationTables = ProjectValidator.listSimulationDischargeTables(config.geopackagePath(),
+			List<String> simulationTables = ProjectValidator.listSimulationTables(config.geopackagePath(),
 					ExplorerConfig.geopackageSimulationPrefix(), 500);
 			return simulationTables.toArray(String[]::new);
 		} catch (SQLException e) {


### PR DESCRIPTION
### Motivation
- Aggiungere supporto alla selezione e visualizzazione dei tipi grafico `fluxes` e `state` (tabelle `sim*` non-discharge) oltre a `discharge` per poter mostrare esplicitamente le serie richieste. 
- Visualizzare per `fluxes` un set fisso di linee semplici con colori stabiliti e per `state` le variazioni impilate (positivi sopra, negativi sotto). 
- Fornire controlli di navigazione (pan/zoom/reset) nella vista grafico e disabilitare le interazioni di stream gauge/metriche quando non si è in `discharge`.

### Description
- Added `listSimulationTables` in `ProjectValidator` to return all `sim*` tables (used to allow picking non-discharge simulation tables). (file: `src/main/java/.../services/ProjectValidator.java`).
- Extended `ChartSetupDialog` to keep the full `sim*` table list and dynamically filter the combo based on selected `type` (`discharge` vs `state`/`fluxes`). (file: `src/main/java/.../plot/ChartSetupDialog.java`).
- Added `TimeValueRow` and new multi-column row loader API `loadRowsFromAnyInput` / `loadRowsFromDb` to `TimeseriesLoader` to extract multiple columns from simulation tables and enable sums/deltas. (file: `src/main/java/.../io/TimeseriesLoader.java`).
- Implemented dedicated plotting logic in `TimeseriesWindow`: `fluxes` loads and plots the requested simple line series with fixed colors (including `canopy_aet + rootzone_aet` summed), `state` computes deltas (`final - initial`, SWE and AET sum) and renders a stacked area view with per-series colors, and `discharge` retains existing behaviour; stream-gauge/metrics UI is disabled in non-`discharge` views. Also added pan toggle, zoom-rectangle toggle and reset zoom controls and enabled mouse wheel zoom for the chart. (file: `src/main/java/.../plot/TimeseriesWindow.java`).
- Updated `SubbasinExplorerPanel` to use the new table discovery method so the setup dialog receives the full `sim*` list. (file: `src/main/java/.../ui/SubbasinExplorerPanel.java`).

### Testing
- Attempted a local compile with `mvn -q -DskipTests compile`, but the build failed due to environment/network artifact resolution (Maven Central returned `403 Forbidden` for the resources plugin), so no successful compile was produced in this environment. 
- No automated unit or integration tests were run as part of this change due to the failing dependency resolution; runtime behavior was validated by inspecting the modified source and smoke-checking the UI wiring in the code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a050adf35c83259e02984ceb0527a9)