### PR TITLE
Docs: Add default legacy timeseries prefixes and validation rules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ Configurable keys in `explorer.properties`:
 - `legacy.files.topology.csv`
 - `legacy.timeseries.prefixes`
 
+Default value for `legacy.timeseries.prefixes` (legacy flux/state components):
+- `C_AET_`, `C_S_`, `C_Throughfall_`, `freezing_`, `GW_S_`, `Md_`, `melting_`,
+  `Q_`, `Q_fast_`, `Q_slow_`, `Q_mm_`, `Q_fast_mm_`, `Q_slow_mm_`, `RZ_AET_`, `RZ_S_`, `SWE_`
+
+How prefixes are used:
+- prefixes are **comma-separated alternatives**;
+- for each subbasin folder `<id>/`, validator looks for files named `<prefix><id>.csv`;
+- files are checked independently (you do **not** need all prefixes for every subbasin);
+- at least one matching/parseable CSV per folder is enough to pass the legacy timeseries check.
+
 ---
 
 ## Usage workflow


### PR DESCRIPTION
### Motivation
- Clarify behavior of the new Legacy folder mode by documenting the default `legacy.timeseries.prefixes` and how the validator matches prefix-based CSV filenames.

### Description
- Updated `README.md` to add a default value for `legacy.timeseries.prefixes` (`C_AET_`, `C_S_`, `C_Throughfall_`, `freezing_`, `GW_S_`, `Md_`, `melting_`, `Q_`, `Q_fast_`, `Q_slow_`, `Q_mm_`, `Q_fast_mm_`, `Q_slow_mm_`, `RZ_AET_`, `RZ_S_`, `SWE_`) and to document that prefixes are comma-separated alternatives, the validator looks for files named `<prefix><id>.csv` inside each subbasin folder, files are checked independently so not all prefixes are required per subbasin, and at least one matching/parseable CSV per folder is sufficient for the legacy timeseries check.

### Testing
- Documentation-only change; no automated tests were modified or run for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a70835344c8325bf2087904b1a9998)