### PR TITLE
Separate GeoPackage/Legacy UI sections and add CSV picker for legacy timeseries

### DIFF
--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/io/TimeseriesLoader.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/io/TimeseriesLoader.java
@@ -70,7 +70,15 @@ public final class TimeseriesLoader {
 		if (!Files.exists(csv) || !Files.isReadable(csv)) {
 			return 0;
 		}
-		return fillSeriesFromLegacyCsv(csv, series);
+		return fillSeriesFromLegacyCsvInternal(csv, series);
+	}
+
+
+	public int fillSeriesFromLegacyCsv(Path csvPath, TimeSeries series) {
+		if (csvPath == null || series == null || !Files.exists(csvPath) || !Files.isReadable(csvPath)) {
+			return 0;
+		}
+		return fillSeriesFromLegacyCsvInternal(csvPath, series);
 	}
 
 	public Set<String> listColumnNamesFromAnyInput(ProjectConfig config, String table) {
@@ -150,7 +158,7 @@ public final class TimeseriesLoader {
 		}
 	}
 
-	private int fillSeriesFromLegacyCsv(Path csvPath, TimeSeries series) {
+	private int fillSeriesFromLegacyCsvInternal(Path csvPath, TimeSeries series) {
 		try (BufferedReader reader = Files.newBufferedReader(csvPath)) {
 			LegacyCsvHeader header = LegacyCsvHeader.read(reader);
 			if (header == null) {

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/plot/TimeseriesWindow.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/plot/TimeseriesWindow.java
@@ -16,6 +16,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -31,6 +33,7 @@ import java.util.function.Supplier;
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JFileChooser;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -42,6 +45,7 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
 import javax.swing.WindowConstants;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
@@ -93,6 +97,7 @@ public final class TimeseriesWindow {
 	private String legacyStreamGaugePrefix;
 	private JLabel addSourceLabel;
 	private JButton addSimulationButton;
+	private JButton metricsButton;
 
 	public TimeseriesWindow(Component parent, ProjectConfig config, TimeseriesLoader loader,
 			Supplier<List<String>> tableSupplier, Supplier<List<String>> basinSupplier,
@@ -282,7 +287,7 @@ public final class TimeseriesWindow {
 		addGaugeButton.addActionListener(e -> addSelectedSeriesFromGaugeCombo());
 		panel.add(addGaugeButton, gbc);
 		gbc.gridy++;
-		JButton metricsButton = new JButton("Calcola metriche (KGE, NSE, NSElog)");
+		metricsButton = new JButton("Calcola metriche (KGE, NSE, NSElog)");
 		metricsButton.addActionListener(e -> showMetricsPopup());
 		panel.add(metricsButton, gbc);
 		return panel;
@@ -334,23 +339,27 @@ public final class TimeseriesWindow {
 			for (String table : filterStreamGaugeTables(tableSupplier.get())) {
 				streamGaugeCombo.addItem(table);
 			}
+			if (metricsButton != null) {
+				metricsButton.setVisible(true);
+			}
 			return;
 		}
 
-		addSourceLabel.setText("Bacino da aggiungere:");
-		addSimulationButton.setText("Carica bacino");
+		addSourceLabel.setText("File CSV simulazione:");
+		addSimulationButton.setText("Carica file simulazione");
 		simulationTableCombo.removeAllItems();
-		simulationTableCombo.addItem("legacy-folder");
+		simulationTableCombo.addItem("selezione file");
 		simulationTableCombo.setEnabled(false);
 		basinCombo.removeAllItems();
 		for (String id : basinSupplier.get()) {
 			basinCombo.addItem(id);
 		}
 		streamGaugeCombo.removeAllItems();
-		for (String id : basinSupplier.get()) {
-			streamGaugeCombo.addItem(id);
+		streamGaugeCombo.addItem("selezione file");
+		streamGaugeCombo.setEnabled(false);
+		if (metricsButton != null) {
+			metricsButton.setVisible(false);
 		}
-		streamGaugeCombo.setEnabled(true);
 	}
 
 
@@ -431,28 +440,44 @@ public final class TimeseriesWindow {
 	}
 
 	private void addLegacyBasinSeries(boolean gaugeSeries) {
-		String basinId = gaugeSeries ? (String) streamGaugeCombo.getSelectedItem() : (String) basinCombo.getSelectedItem();
-		if (basinId == null || basinId.isBlank()) {
-			appendLog("Seleziona un bacino.");
-			return;
-		}
 		if (!"discharge".equalsIgnoreCase(activeType)) {
 			appendLog("Legacy mode: al momento è supportato solo il grafico discharge da file.");
 			return;
 		}
-		String prefix = gaugeSeries ? legacyStreamGaugePrefix : legacyDischargePrefix;
-		TimeSeries series = new TimeSeries((gaugeSeries ? "gauge " : "sim ") + prefix + basinId + ".csv");
-		int count = loader.fillSeriesFromLegacyFolder(config, basinId, prefix, series);
+		Path selectedCsv = chooseLegacyCsvFile(gaugeSeries ? "Seleziona file CSV osservato" : "Seleziona file CSV simulato");
+		if (selectedCsv == null) {
+			appendLog("Selezione file annullata.");
+			return;
+		}
+		TimeSeries series = new TimeSeries((gaugeSeries ? "gauge " : "sim ") + selectedCsv.getFileName());
+		int count = loader.fillSeriesFromLegacyCsv(selectedCsv, series);
 		if (count <= 0) {
-			appendLog("Nessun dato trovato nel file legacy " + prefix + basinId + ".csv per bacino " + basinId + ".");
+			appendLog("Nessun dato trovato nel file legacy " + selectedCsv.getFileName() + ".");
 			return;
 		}
 		dataset.addSeries(series);
 		applySeriesStyles();
 		reloadSeriesList();
-		appendLog("Aggiunta serie legacy: " + prefix + basinId + ".csv | punti: " + count);
+		appendLog("Aggiunta serie legacy: " + selectedCsv.getFileName() + " | punti: " + count);
 	}
 
+
+
+	private Path chooseLegacyCsvFile(String title) {
+		JFileChooser chooser = new JFileChooser();
+		chooser.setDialogTitle(title);
+		chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+		chooser.setAcceptAllFileFilterUsed(true);
+		chooser.setFileFilter(new FileNameExtensionFilter("CSV files", "csv"));
+		if (config != null && config.legacyRootPath() != null && Files.exists(config.legacyRootPath())) {
+			chooser.setCurrentDirectory(config.legacyRootPath().toFile());
+		}
+		int result = chooser.showOpenDialog(dialog);
+		if (result == JFileChooser.APPROVE_OPTION && chooser.getSelectedFile() != null) {
+			return chooser.getSelectedFile().toPath();
+		}
+		return null;
+	}
 
 	private void addFluxesSeries(String table) {
 		if (config.mode() == ProjectMode.LEGACY_FOLDER) {
@@ -748,6 +773,11 @@ public final class TimeseriesWindow {
 	}
 
 	private void showMetricsPopup() {
+		if (config.mode() == ProjectMode.LEGACY_FOLDER) {
+			appendLog("Metriche da popup non disponibili in legacy mode.");
+			return;
+		}
+
 		List<TimeSeries> simulationSeries = getSimulationSeries();
 		List<TimeSeries> gaugeSeries = getGaugeSeries();
 		if (simulationSeries.isEmpty()) {

--- a/src/main/java/it/geoframe/blogpost/subbasins/explorer/ui/LoadFileView.java
+++ b/src/main/java/it/geoframe/blogpost/subbasins/explorer/ui/LoadFileView.java
@@ -67,6 +67,8 @@ public class LoadFileView extends JPanel {
 	private final JButton m_browseLegacyRootButton = new JButton("Browse…");
 
 	private final JButton m_continueButton = new JButton("Continue");
+	private final JPanel m_geopackageSection = new JPanel();
+	private final JPanel m_legacySection = new JPanel();
 
 	public LoadFileView() {
 		buildUi();
@@ -273,6 +275,9 @@ public class LoadFileView extends JPanel {
 		m_sqlitePathField.setEnabled(enabled);
 		m_browseGeopButton.setEnabled(enabled);
 		m_browseSqliteButton.setEnabled(enabled);
+		m_geopackageSection.setVisible(enabled);
+		revalidate();
+		repaint();
 	}
 
 	public void setLegacyEnabled(boolean enabled) {
@@ -285,6 +290,9 @@ public class LoadFileView extends JPanel {
 		m_legacyTopologyCsvField.setEnabled(enabled);
 		m_legacyPrefixesField.setEnabled(enabled);
 		m_browseLegacyRootButton.setEnabled(enabled);
+		m_legacySection.setVisible(enabled);
+		revalidate();
+		repaint();
 	}
 
 	private void buildUi() {
@@ -309,26 +317,32 @@ public class LoadFileView extends JPanel {
 		content.add(modeRow);
 		content.add(Box.createVerticalStrut(16));
 
-		content.add(sectionRow(m_geopLabel, m_geopPathField, m_browseGeopButton));
-		content.add(Box.createVerticalStrut(12));
-		content.add(sectionRow(m_inputLabel, m_sqlitePathField, m_browseSqliteButton));
+		m_geopackageSection.setOpaque(false);
+		m_geopackageSection.setLayout(new BoxLayout(m_geopackageSection, BoxLayout.Y_AXIS));
+		m_geopackageSection.add(sectionRow(m_geopLabel, m_geopPathField, m_browseGeopButton));
+		m_geopackageSection.add(Box.createVerticalStrut(12));
+		m_geopackageSection.add(sectionRow(m_inputLabel, m_sqlitePathField, m_browseSqliteButton));
+		content.add(m_geopackageSection);
 		content.add(Box.createVerticalStrut(16));
 
-		content.add(sectionRow(m_legacyRootLabel, m_legacyRootField, m_browseLegacyRootButton));
-		content.add(Box.createVerticalStrut(10));
-		content.add(sectionRow(m_legacyShpIdLabel, m_legacyShpIdField, null));
-		content.add(Box.createVerticalStrut(10));
-		content.add(sectionRow(m_legacyCsvIdLabel, m_legacyCsvIdField, null));
-		content.add(Box.createVerticalStrut(10));
-		content.add(sectionRow(m_legacySubbasinShpLabel, m_legacySubbasinShpField, null));
-		content.add(Box.createVerticalStrut(10));
-		content.add(sectionRow(m_legacyNetworkShpLabel, m_legacyNetworkShpField, null));
-		content.add(Box.createVerticalStrut(10));
-		content.add(sectionRow(m_legacySubbasinsCsvLabel, m_legacySubbasinsCsvField, null));
-		content.add(Box.createVerticalStrut(10));
-		content.add(sectionRow(m_legacyTopologyCsvLabel, m_legacyTopologyCsvField, null));
-		content.add(Box.createVerticalStrut(10));
-		content.add(sectionRow(m_legacyPrefixesLabel, m_legacyPrefixesField, null));
+		m_legacySection.setOpaque(false);
+		m_legacySection.setLayout(new BoxLayout(m_legacySection, BoxLayout.Y_AXIS));
+		m_legacySection.add(sectionRow(m_legacyRootLabel, m_legacyRootField, m_browseLegacyRootButton));
+		m_legacySection.add(Box.createVerticalStrut(10));
+		m_legacySection.add(sectionRow(m_legacyShpIdLabel, m_legacyShpIdField, null));
+		m_legacySection.add(Box.createVerticalStrut(10));
+		m_legacySection.add(sectionRow(m_legacyCsvIdLabel, m_legacyCsvIdField, null));
+		m_legacySection.add(Box.createVerticalStrut(10));
+		m_legacySection.add(sectionRow(m_legacySubbasinShpLabel, m_legacySubbasinShpField, null));
+		m_legacySection.add(Box.createVerticalStrut(10));
+		m_legacySection.add(sectionRow(m_legacyNetworkShpLabel, m_legacyNetworkShpField, null));
+		m_legacySection.add(Box.createVerticalStrut(10));
+		m_legacySection.add(sectionRow(m_legacySubbasinsCsvLabel, m_legacySubbasinsCsvField, null));
+		m_legacySection.add(Box.createVerticalStrut(10));
+		m_legacySection.add(sectionRow(m_legacyTopologyCsvLabel, m_legacyTopologyCsvField, null));
+		m_legacySection.add(Box.createVerticalStrut(10));
+		m_legacySection.add(sectionRow(m_legacyPrefixesLabel, m_legacyPrefixesField, null));
+		content.add(m_legacySection);
 		content.add(Box.createVerticalStrut(14));
 
 		JLabel logLabel = new JLabel("Checks / log");


### PR DESCRIPTION
### Motivation
- Improve UX by fully separating GeoPackage and Legacy input controls so fields and buttons for one mode are hidden when the other is selected.
- Make legacy-mode charting more flexible by allowing users to pick individual legacy CSV files (simulated or observed) instead of relying on strict filename conventions.

### Description
- Split the project loader UI into two dedicated panels and toggle visibility with `setGeopackageEnabled` / `setLegacyEnabled`, moving GeoPackage fields into `m_geopackageSection` and legacy fields into `m_legacySection` in `LoadFileView`.
- In `TimeseriesWindow` hide GeoPackage-specific controls (including the metrics button) when in legacy mode and adapt labels/buttons to reflect file-based loading (e.g. change "Carica simulazione" to "Carica file simulazione").
- Add a file chooser (`chooseLegacyCsvFile`) in `TimeseriesWindow` that starts in the configured legacy root folder and filters for `.csv` files, and use it to load legacy discharge/stream-gauge CSVs.
- Expose a new public `TimeseriesLoader.fillSeriesFromLegacyCsv(Path, TimeSeries)` which delegates to the existing CSV parsing logic (renamed to `fillSeriesFromLegacyCsvInternal`) so selected CSV files can be loaded directly while preserving folder-based loading.

### Testing
- Ran `mvn -q test` in the project root and it failed due to environment dependency resolution (Maven could not download `maven-resources-plugin:3.3.1` from Maven Central returning HTTP 403), so unit tests could not be executed to completion.
- No other automated tests were executed in this environment; changes are limited to Swing UI and loader call paths and should be verified by running the application and exercising GeoPackage vs Legacy workflows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8380e9b608325999edc55bbe3f8e1)